### PR TITLE
Add Lisp test runner example

### DIFF
--- a/lispy.py
+++ b/lispy.py
@@ -16,6 +16,17 @@ Symbol = str
 ListType = list
 Number = (int, float)
 
+
+def _print_lisp(*args: Any) -> None:
+    """Primitive print function for Lispy."""
+    def _to_string(exp: Any) -> str:
+        if isinstance(exp, list):
+            return '(' + ' '.join(map(_to_string, exp)) + ')'
+        return str(exp)
+
+    print(' '.join(_to_string(a) for a in args))
+
+
 class Env(dict):
     """Environment mapping symbols to values."""
 
@@ -66,6 +77,7 @@ def standard_env() -> Env:
         'null?': lambda x: x == [],
         'symbol?': lambda x: isinstance(x, str),
         'progn': lambda *x: x[-1] if x else None,
+        'print': _print_lisp,
         'nil': None,
     })
     env.update(vars(math))  # sin, cos, sqrt, pi, ...

--- a/tests/test_lispy.py
+++ b/tests/test_lispy.py
@@ -15,3 +15,23 @@ def run_lispy(source: str) -> str:
 def test_run_file():
     out = run_lispy('(define x 41)\n(+ x 1)')
     assert out == '42'
+
+
+def test_lisp_test_suite():
+    source = """
+(define failures 0)
+
+(define assert-eq
+  (lambda (name actual expected)
+    (if (= actual expected)
+        (progn (print (quote PASS) name) nil)
+        (progn (print (quote FAIL) name (quote expected) expected (quote got) actual)
+               (define failures (+ failures 1))
+               nil))))
+
+(assert-eq (quote addition) (+ 1 1) 2)
+(assert-eq (quote car) (car (list 1 2 3)) 1)
+(if (= failures 0) 0 1)
+"""
+    out = run_lispy(source)
+    assert out.splitlines()[-1] == '0'


### PR DESCRIPTION
## Summary
- add `_print_lisp` primitive and expose as `print`
- add new lisp-based tests showcasing primitive usage

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6879a36f30b8832a98c072bb73243a27